### PR TITLE
Legacy toggle and export/import function

### DIFF
--- a/src/components/Encounter/CreaturesTable/EncounterBuilder.vue
+++ b/src/components/Encounter/CreaturesTable/EncounterBuilder.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { useQuasar } from 'quasar';
-import { matPriorityHigh } from '@quasar/extras/material-icons';
-import { matArrowDropDown, matCancel } from '@quasar/extras/material-icons';
+import { matPriorityHigh, matArrowDropDown, matCancel } from '@quasar/extras/material-icons';
 import { biXLg } from '@quasar/extras/bootstrap-icons';
 import { partyStore, filtersStore, encounterStore } from 'src/stores/store';
 import { encounterGenerator } from 'src/utils/api-calls';

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -353,11 +353,11 @@ const downloadData = () => {
                       @click="uploadData"
                     >
                       <q-tooltip
-                        class="text-caption tw-bg-red-700 tw-text-grey-400 tw-rounded-md tw-shadow-sm dark:tw-bg-red-700"
+                        class="text-caption tw-bg-amber-400 tw-text-gray-800 tw-rounded-md tw-shadow-sm dark:tw-bg-amber-400"
                         anchor="top middle"
                         self="bottom middle"
                       >
-                        Backup your data by exporting first!
+                        Remember to backup your data by exporting first!
                       </q-tooltip>
                     </q-btn>
                   </q-card-actions>

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -289,7 +289,21 @@ const downloadData = () => {
                   </q-card-actions>
                   <q-separator />
                   <q-card-actions>
-                    <q-toggle v-model="legacy" label="Legacy" @update:model-value="toggleLegacy" />
+                    <q-toggle
+                      disable
+                      v-model="legacy"
+                      label="Legacy"
+                      @update:model-value="toggleLegacy"
+                    >
+                      <q-tooltip
+                        class="text-caption text-center tw-bg-gray-700 tw-text-gray-200 tw-rounded-md tw-shadow-sm dark:tw-bg-slate-700"
+                        anchor="top middle"
+                        self="bottom middle"
+                      >
+                        Work in progress! <br />
+                        Waiting for the Monster Core
+                      </q-tooltip>
+                    </q-toggle>
                   </q-card-actions>
                 </q-card-section>
               </q-card>


### PR DESCRIPTION
Added a setting dialog, accessible from the header. Inside there are 3 new buttons:

- Export Data: downloads a .json file with all local storage data as a backup
- Import Data: imports a .json file to local storage to restore previously downloaded data
- Legacy: a toggle to use Pathfinder 2e Legacy instead of the Remaster

The legacy button will do nothing until the Monster Core gets released.

Todo:

- [x] add checks on the imported file (closes #14)
- [x] disable or add a tooltip to the toggle to show it's still a WIP