### PR TITLE
🐛 Fixed elite level for creatures of level 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bybe-frontend",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Beyond Your Bestiary Explorer (BYBE) is a one-stop shop for the most useful tools for Pathfinder Second Edition GMs",
   "productName": "BYBE - Pathfinder 2e GM Tools",
   "author": "TheAsel",

--- a/src/components/Encounter/CreatureList.vue
+++ b/src/components/Encounter/CreatureList.vue
@@ -37,14 +37,14 @@ const debouncedCall = debounce(async function () {
       switch (creature.variant) {
         case 'Weak':
           if (creature.level === 1) {
-            enemyLevels.push(-1);
+            enemyLevels.push(creature.level - 2);
           } else {
             enemyLevels.push(creature.level - 1);
           }
           break;
         case 'Elite':
-          if (creature.level === -1) {
-            enemyLevels.push(1);
+          if (creature.level === -1 || creature.level === 0) {
+            enemyLevels.push(creature.level + 2);
           } else {
             enemyLevels.push(creature.level + 1);
           }


### PR DESCRIPTION
Fixes a bug that caused Elite creatures of level 0 to become of level 1 instead of level 2

https://2e.aonprd.com/Rules.aspx?ID=3264