### PR TITLE
🔧 Switched to .env for auto-open of browser

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 API_URL='https://backbybe.fly.dev'
+AUTO_OPEN_BROWSER=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bybe-frontend",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bybe-frontend",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dependencies": {
         "@quasar/extras": "^1.16.12",
         "@unhead/vue": "^1.11.7",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "echo \"No test specified\" && exit 0",
     "dev": "quasar dev",
     "build": "quasar build",
-    "start": "./node_modules/@quasar/cli/bin/quasar.js serve dist/spa --history --open --hostname localhost"
+    "start": "./node_modules/@quasar/cli/bin/quasar.js serve dist/spa --history --hostname localhost"
   },
   "dependencies": {
     "@quasar/extras": "^1.16.12",

--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -82,7 +82,7 @@ export default configure((/* ctx */) => {
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#devServer
     devServer: {
       // https: true
-      open: true // opens browser window automatically
+      open: process.env.AUTO_OPEN_BROWSER === 'true' // opens browser window automatically
     },
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#framework


### PR DESCRIPTION
This is a PR made to improve the bundling of the "BYBE-Portable" application
This option helps with tauri dev bundles and CI actions