### PR TITLE
🎨 Remove Ko-Fi widget from DOM when hidden

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,18 +63,5 @@
   </head>
   <body>
     <!-- quasar:entry-point -->
-    <script
-      src="https://storage.ko-fi.com/cdn/scripts/overlay-widget.js"
-      integrity="sha384-4VTAIPa7wvHSDJMT8MfIGjeEbXASOBA77epDpVRQtDVTUsNX/7CwMwduSyirANhd sha384-jGw6wt6amAt5Rwe5EdDa+wll23XiHB4nWU3uXZhEWxxuQgzWa7UlGBpnauIcXt9M"
-      crossorigin="anonymous"
-    ></script>
-    <script>
-      kofiWidgetOverlay.draw('theasel', {
-        type: 'floating-chat',
-        'floating-chat.donateButton.text': 'Support Us',
-        'floating-chat.donateButton.background-color': '#00b9fe',
-        'floating-chat.donateButton.text-color': '#fff'
-      });
-    </script>
   </body>
 </html>

--- a/src/pages/ErrorNotFound.vue
+++ b/src/pages/ErrorNotFound.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { ref } from 'vue';
 import { useHead } from '@unhead/vue';
 
 useHead({
@@ -11,12 +10,6 @@ useHead({
     }
   ]
 });
-
-const supportButton = ref(
-  document.querySelectorAll('[id^=kofi-widget-overlay-]').item(0) as HTMLElement
-);
-
-supportButton.value.style.display = 'none';
 </script>
 
 <template>


### PR DESCRIPTION
Moved the Ko-Fi widget declaration away from the index.html, enabling more control over it. Now when the button is disabled, it's completely removed from the page, not just hidden. Should improve load time, remove console errors and prevent third-party connections/cookies.