### PR TITLE
🩹 Don't show download button from app

### DIFF
--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -25,6 +25,7 @@ import type { template } from '../types/template';
 
 const encounter = encounterStore();
 const settings = settingsStore();
+const isApp = process.env.IS_APP;
 
 TailwindDarkFix();
 
@@ -527,6 +528,7 @@ const downloadData = () => {
           <q-space class="sm:tw-block tw-hidden" />
           <q-separator class="tw-block sm:tw-hidden" />
           <router-link
+            v-if="isApp === 'false'"
             to="/download"
             :class="
               currentPath === '/download'


### PR DESCRIPTION
Small fix to hide the download button from the header when using the offline application